### PR TITLE
Implement grid and piece spawning with validation tests

### DIFF
--- a/Assets/Scripts/BoardGrid.cs
+++ b/Assets/Scripts/BoardGrid.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// Manages an 8x8 grid of blocks, handles placement and clearing of lines.
+/// </summary>
+public class BoardGrid
+{
+    public const int Size = 8;
+    private readonly bool[,] _cells = new bool[Size, Size];
+
+    /// <summary>
+    /// Invoked when one or more lines are cleared.
+    /// </summary>
+    public event Action<int> LinesCleared;
+
+    /// <summary>
+    /// Total score accumulated.
+    /// </summary>
+    public int Score { get; private set; }
+
+    /// <summary>
+    /// Returns whether the specified cell is occupied.
+    /// </summary>
+    /// <param name="x">X coordinate.</param>
+    /// <param name="y">Y coordinate.</param>
+    public bool GetCell(int x, int y)
+    {
+        if (x < 0 || x >= Size || y < 0 || y >= Size)
+        {
+            throw new ArgumentOutOfRangeException();
+        }
+
+        return _cells[x, y];
+    }
+
+    /// <summary>
+    /// Sets a cell to the provided value without triggering line clears.
+    /// Intended for setup or tests.
+    /// </summary>
+    public void SetCell(int x, int y, bool occupied)
+    {
+        if (x < 0 || x >= Size || y < 0 || y >= Size)
+        {
+            throw new ArgumentOutOfRangeException();
+        }
+
+        _cells[x, y] = occupied;
+    }
+
+    /// <summary>
+    /// Places a piece on the grid and clears any full lines.
+    /// </summary>
+    /// <param name="piece">Piece shape represented as a 2D boolean array.</param>
+    /// <param name="x">Left position.</param>
+    /// <param name="y">Top position.</param>
+    public void PlacePiece(bool[,] piece, int x, int y)
+    {
+        if (piece == null)
+        {
+            throw new ArgumentNullException(nameof(piece));
+        }
+
+        int height = piece.GetLength(0);
+        int width = piece.GetLength(1);
+
+        for (int r = 0; r < height; r++)
+        {
+            for (int c = 0; c < width; c++)
+            {
+                if (!piece[r, c])
+                {
+                    continue;
+                }
+
+                _cells[x + c, y + r] = true;
+            }
+        }
+
+        int cleared = ClearLines();
+        if (cleared > 0)
+        {
+            Score += cleared * 10;
+            LinesCleared?.Invoke(cleared);
+        }
+    }
+
+    private int ClearLines()
+    {
+        List<int> rowsToClear = new List<int>();
+        List<int> colsToClear = new List<int>();
+
+        for (int r = 0; r < Size; r++)
+        {
+            bool full = true;
+            for (int c = 0; c < Size; c++)
+            {
+                if (!_cells[c, r])
+                {
+                    full = false;
+                    break;
+                }
+            }
+
+            if (full)
+            {
+                rowsToClear.Add(r);
+            }
+        }
+
+        for (int c = 0; c < Size; c++)
+        {
+            bool full = true;
+            for (int r = 0; r < Size; r++)
+            {
+                if (!_cells[c, r])
+                {
+                    full = false;
+                    break;
+                }
+            }
+
+            if (full)
+            {
+                colsToClear.Add(c);
+            }
+        }
+
+        foreach (int r in rowsToClear)
+        {
+            for (int c = 0; c < Size; c++)
+            {
+                _cells[c, r] = false;
+            }
+        }
+
+        foreach (int c in colsToClear)
+        {
+            for (int r = 0; r < Size; r++)
+            {
+                _cells[c, r] = false;
+            }
+        }
+
+        return rowsToClear.Count + colsToClear.Count;
+    }
+}
+

--- a/Assets/Scripts/PieceSpawner.cs
+++ b/Assets/Scripts/PieceSpawner.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// Provides random block pieces used in gameplay.
+/// </summary>
+public class PieceSpawner
+{
+    private readonly Random _random;
+    private readonly List<bool[,]> _pieces = new List<bool[,]>();
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="PieceSpawner"/>.
+    /// </summary>
+    /// <param name="seed">Optional random seed for deterministic results.</param>
+    public PieceSpawner(int? seed = null)
+    {
+        _random = seed.HasValue ? new Random(seed.Value) : new Random();
+        _pieces.Add(new bool[,]
+        {
+            { true, true },
+            { true, true }
+        }); // Square
+
+        _pieces.Add(new bool[,]
+        {
+            { true, true, true },
+            { false, true, false }
+        }); // T
+
+        _pieces.Add(new bool[,]
+        {
+            { true, false },
+            { true, false },
+            { true, true }
+        }); // L
+
+        _pieces.Add(new bool[,]
+        {
+            { true, true, true, true }
+        }); // Line
+    }
+
+    /// <summary>
+    /// Returns a random piece shape.
+    /// </summary>
+    public bool[,] GetRandomPiece()
+    {
+        int index = _random.Next(_pieces.Count);
+        return (bool[,])_pieces[index].Clone();
+    }
+
+    /// <summary>
+    /// Returns all available piece shapes.
+    /// </summary>
+    public IEnumerable<bool[,]> AllPieces
+    {
+        get
+        {
+            foreach (var piece in _pieces)
+            {
+                yield return (bool[,])piece.Clone();
+            }
+        }
+    }
+}
+

--- a/Assets/Scripts/PlacementValidator.cs
+++ b/Assets/Scripts/PlacementValidator.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// Validates whether pieces can be placed on the board.
+/// </summary>
+public class PlacementValidator
+{
+    /// <summary>
+    /// Checks if a piece can be placed at the given position.
+    /// </summary>
+    /// <param name="board">Board to evaluate.</param>
+    /// <param name="piece">Piece shape.</param>
+    /// <param name="x">Left position.</param>
+    /// <param name="y">Top position.</param>
+    public bool CanPlace(BoardGrid board, bool[,] piece, int x, int y)
+    {
+        if (board == null || piece == null)
+        {
+            return false;
+        }
+
+        int height = piece.GetLength(0);
+        int width = piece.GetLength(1);
+
+        if (x < 0 || y < 0 || x + width > BoardGrid.Size || y + height > BoardGrid.Size)
+        {
+            return false;
+        }
+
+        for (int r = 0; r < height; r++)
+        {
+            for (int c = 0; c < width; c++)
+            {
+                if (!piece[r, c])
+                {
+                    continue;
+                }
+
+                if (board.GetCell(x + c, y + r))
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Determines if any piece from the list can fit on the board.
+    /// </summary>
+    /// <param name="board">Board to evaluate.</param>
+    /// <param name="pieces">Pieces to test.</param>
+    public bool HasAnyValidPlacement(BoardGrid board, IEnumerable<bool[,]> pieces)
+    {
+        if (board == null || pieces == null)
+        {
+            return false;
+        }
+
+        foreach (var piece in pieces)
+        {
+            int height = piece.GetLength(0);
+            int width = piece.GetLength(1);
+            for (int y = 0; y <= BoardGrid.Size - height; y++)
+            {
+                for (int x = 0; x <= BoardGrid.Size - width; x++)
+                {
+                    if (CanPlace(board, piece, x, y))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+}
+

--- a/Assets/Tests/BoardGridTests.cs
+++ b/Assets/Tests/BoardGridTests.cs
@@ -1,0 +1,78 @@
+using NUnit.Framework;
+
+public class BoardGridTests
+{
+    [Test]
+    public void ClearsRowsAndColumns()
+    {
+        BoardGrid grid = new BoardGrid();
+        PlacementValidator validator = new PlacementValidator();
+        bool[,] single = { { true } };
+        int linesCleared = 0;
+        grid.LinesCleared += count => linesCleared += count;
+
+        for (int x = 0; x < BoardGrid.Size; x++)
+        {
+            Assert.IsTrue(validator.CanPlace(grid, single, x, 0));
+            grid.PlacePiece(single, x, 0);
+        }
+
+        Assert.AreEqual(1, linesCleared);
+        for (int x = 0; x < BoardGrid.Size; x++)
+        {
+            Assert.IsFalse(grid.GetCell(x, 0));
+        }
+
+        for (int y = 0; y < BoardGrid.Size; y++)
+        {
+            Assert.IsTrue(validator.CanPlace(grid, single, 0, y));
+            grid.PlacePiece(single, 0, y);
+        }
+
+        Assert.AreEqual(2, linesCleared);
+        for (int y = 0; y < BoardGrid.Size; y++)
+        {
+            Assert.IsFalse(grid.GetCell(0, y));
+        }
+    }
+
+    [Test]
+    public void AwardsScoreOnClear()
+    {
+        BoardGrid grid = new BoardGrid();
+        bool[,] single = { { true } };
+
+        for (int x = 0; x < BoardGrid.Size; x++)
+        {
+            grid.PlacePiece(single, x, 0);
+        }
+
+        Assert.AreEqual(10, grid.Score);
+    }
+
+    [Test]
+    public void DetectsGameOverWhenNoPlacementsRemain()
+    {
+        BoardGrid grid = new BoardGrid();
+        bool[,] single = { { true } };
+
+        for (int x = 0; x < BoardGrid.Size; x++)
+        {
+            for (int y = 0; y < BoardGrid.Size; y++)
+            {
+                if (x == 0 && y == 0)
+                {
+                    continue;
+                }
+
+                grid.SetCell(x, y, true);
+            }
+        }
+
+        PieceSpawner spawner = new PieceSpawner(0);
+        PlacementValidator validator = new PlacementValidator();
+        bool possible = validator.HasAnyValidPlacement(grid, spawner.AllPieces);
+        Assert.IsFalse(possible);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Add BoardGrid to manage 8x8 board, clear lines, and track score
- Introduce PieceSpawner for basic Tetris-style shapes
- Provide PlacementValidator to check and scan valid placements
- Create NUnit tests for line clearing, scoring, and game over detection

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fa56566c832a9c6a24cb95dafdfe