### PR TITLE
Add board grid logic with spawner, validation, and tests

### DIFF
--- a/Assets/Scripts/BoardGrid.cs
+++ b/Assets/Scripts/BoardGrid.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+
+namespace TetrisMania
+{
+    /// <summary>
+    /// Represents a block shape composed of a grid of cells.
+    /// </summary>
+    public class BlockShape
+    {
+        /// <summary>
+        /// Gets the shape cells where <c>true</c> indicates an occupied block.
+        /// </summary>
+        public bool[,] Cells { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BlockShape"/> class.
+        /// </summary>
+        /// <param name="cells">Two dimensional array describing the shape.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="cells"/> is null.</exception>
+        public BlockShape(bool[,] cells)
+        {
+            Cells = cells ?? throw new ArgumentNullException(nameof(cells));
+        }
+    }
+
+    /// <summary>
+    /// Manages the main 8x8 board grid, handling block placement and line clears.
+    /// </summary>
+    public class BoardGrid
+    {
+        /// <summary>
+        /// Size of the board on each axis.
+        /// </summary>
+        public const int Size = 8;
+
+        private readonly bool[,] _grid = new bool[Size, Size];
+        private readonly PlacementValidator _validator = new PlacementValidator();
+
+        /// <summary>
+        /// Raised whenever one or more lines are cleared.
+        /// </summary>
+        public event Action<int>? LinesCleared;
+
+        /// <summary>
+        /// Gets the player's score.
+        /// </summary>
+        public int Score { get; private set; }
+
+        /// <summary>
+        /// Attempts to place a shape at the specified board coordinates.
+        /// </summary>
+        /// <param name="shape">Shape to place.</param>
+        /// <param name="x">X-coordinate of the top-left position.</param>
+        /// <param name="y">Y-coordinate of the top-left position.</param>
+        /// <returns><c>true</c> if placement succeeded; otherwise, <c>false</c>.</returns>
+        public bool TryPlacePiece(BlockShape shape, int x, int y)
+        {
+            if (shape == null)
+            {
+                return false;
+            }
+
+            if (!_validator.CanPlace(_grid, shape, x, y))
+            {
+                return false;
+            }
+
+            PlaceShape(shape, x, y);
+            var cleared = ClearLines();
+            if (cleared > 0)
+            {
+                Score += cleared * 100;
+                LinesCleared?.Invoke(cleared);
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Determines whether any of the provided shapes can be placed on the board.
+        /// </summary>
+        /// <param name="shapes">Collection of shapes to test.</param>
+        /// <returns><c>true</c> if any shape fits; otherwise, <c>false</c>.</returns>
+        public bool HasAnyValidPlacement(IEnumerable<BlockShape> shapes)
+        {
+            if (shapes == null)
+            {
+                return false;
+            }
+
+            foreach (var shape in shapes)
+            {
+                if (shape == null)
+                {
+                    continue;
+                }
+
+                for (var y = 0; y < Size; y++)
+                {
+                    for (var x = 0; x < Size; x++)
+                    {
+                        if (_validator.CanPlace(_grid, shape, x, y))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns whether a specific cell is occupied.
+        /// </summary>
+        /// <param name="x">X-coordinate.</param>
+        /// <param name="y">Y-coordinate.</param>
+        /// <returns><c>true</c> if the cell contains a block; otherwise, <c>false</c>.</returns>
+        public bool IsCellOccupied(int x, int y)
+        {
+            return _grid[y, x];
+        }
+
+        private void PlaceShape(BlockShape shape, int startX, int startY)
+        {
+            for (var y = 0; y < shape.Cells.GetLength(0); y++)
+            {
+                for (var x = 0; x < shape.Cells.GetLength(1); x++)
+                {
+                    if (shape.Cells[y, x])
+                    {
+                        _grid[startY + y, startX + x] = true;
+                    }
+                }
+            }
+        }
+
+        private int ClearLines()
+        {
+            var cleared = 0;
+
+            // Clear full rows
+            for (var y = 0; y < Size; y++)
+            {
+                var full = true;
+                for (var x = 0; x < Size; x++)
+                {
+                    if (!_grid[y, x])
+                    {
+                        full = false;
+                        break;
+                    }
+                }
+
+                if (full)
+                {
+                    cleared++;
+                    for (var x = 0; x < Size; x++)
+                    {
+                        _grid[y, x] = false;
+                    }
+                }
+            }
+
+            // Clear full columns
+            for (var x = 0; x < Size; x++)
+            {
+                var full = true;
+                for (var y = 0; y < Size; y++)
+                {
+                    if (!_grid[y, x])
+                    {
+                        full = false;
+                        break;
+                    }
+                }
+
+                if (full)
+                {
+                    cleared++;
+                    for (var y = 0; y < Size; y++)
+                    {
+                        _grid[y, x] = false;
+                    }
+                }
+            }
+
+            return cleared;
+        }
+    }
+}
+

--- a/Assets/Scripts/PieceSpawner.cs
+++ b/Assets/Scripts/PieceSpawner.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+
+namespace TetrisMania
+{
+    /// <summary>
+    /// Provides random block shapes for gameplay.
+    /// </summary>
+    public class PieceSpawner
+    {
+        private readonly Random _random = new Random();
+        private readonly List<BlockShape> _shapes;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PieceSpawner"/> class.
+        /// </summary>
+        public PieceSpawner()
+        {
+            _shapes = new List<BlockShape>
+            {
+                // T shape
+                new BlockShape(new bool[,]
+                {
+                    { true, true, true },
+                    { false, true, false }
+                }),
+                // L shape
+                new BlockShape(new bool[,]
+                {
+                    { true, false },
+                    { true, false },
+                    { true, true }
+                }),
+                // Square
+                new BlockShape(new bool[,]
+                {
+                    { true, true },
+                    { true, true }
+                }),
+                // Line
+                new BlockShape(new bool[,]
+                {
+                    { true, true, true, true }
+                })
+            };
+        }
+
+        /// <summary>
+        /// Gets the available shapes.
+        /// </summary>
+        public IReadOnlyList<BlockShape> Shapes => _shapes;
+
+        /// <summary>
+        /// Returns a random block shape.
+        /// </summary>
+        /// <returns>A randomly selected <see cref="BlockShape"/>.</returns>
+        public BlockShape GetRandomShape()
+        {
+            var index = _random.Next(_shapes.Count);
+            return _shapes[index];
+        }
+    }
+}
+

--- a/Assets/Scripts/PlacementValidator.cs
+++ b/Assets/Scripts/PlacementValidator.cs
@@ -1,0 +1,54 @@
+using System;
+
+namespace TetrisMania
+{
+    /// <summary>
+    /// Validates whether a block shape can be placed on the board grid.
+    /// </summary>
+    public class PlacementValidator
+    {
+        /// <summary>
+        /// Determines if the specified shape fits at the given coordinates.
+        /// </summary>
+        /// <param name="grid">Current grid state.</param>
+        /// <param name="shape">Shape to test.</param>
+        /// <param name="startX">X-coordinate of the top-left placement position.</param>
+        /// <param name="startY">Y-coordinate of the top-left placement position.</param>
+        /// <returns><c>true</c> if the shape fits without overlap or going out of bounds; otherwise, <c>false</c>.</returns>
+        public bool CanPlace(bool[,] grid, BlockShape shape, int startX, int startY)
+        {
+            if (grid == null || shape == null)
+            {
+                return false;
+            }
+
+            var size = grid.GetLength(0);
+            for (var y = 0; y < shape.Cells.GetLength(0); y++)
+            {
+                for (var x = 0; x < shape.Cells.GetLength(1); x++)
+                {
+                    if (!shape.Cells[y, x])
+                    {
+                        continue;
+                    }
+
+                    var gx = startX + x;
+                    var gy = startY + y;
+
+                    if (gx < 0 || gy < 0 || gx >= size || gy >= size)
+                    {
+                        return false;
+                    }
+
+                    if (grid[gy, gx])
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+    }
+}
+

--- a/Assets/Tests/BoardGridTests.cs
+++ b/Assets/Tests/BoardGridTests.cs
@@ -1,0 +1,72 @@
+using NUnit.Framework;
+using System.Collections.Generic;
+using TetrisMania;
+
+namespace TetrisMania.Tests
+{
+    public class BoardGridTests
+    {
+        [Test]
+        public void ClearsFullRowAndColumn()
+        {
+            var board = new BoardGrid();
+            var clearedTotal = 0;
+            board.LinesCleared += c => clearedTotal += c;
+
+            var rowShape = new BlockShape(new bool[,] {
+                { true, true, true, true, true, true, true, true }
+            });
+
+            Assert.IsTrue(board.TryPlacePiece(rowShape, 0, 0));
+            Assert.IsFalse(board.IsCellOccupied(0, 0));
+            Assert.AreEqual(1, clearedTotal);
+
+            var columnShape = new BlockShape(new bool[,] {
+                { true }, { true }, { true }, { true }, { true }, { true }, { true }, { true }
+            });
+
+            Assert.IsTrue(board.TryPlacePiece(columnShape, 0, 0));
+            Assert.IsFalse(board.IsCellOccupied(0, 0));
+            Assert.AreEqual(2, clearedTotal);
+        }
+
+        [Test]
+        public void AwardsScoreForClears()
+        {
+            var board = new BoardGrid();
+
+            var rowShape = new BlockShape(new bool[,] {
+                { true, true, true, true, true, true, true, true }
+            });
+            board.TryPlacePiece(rowShape, 0, 0);
+            Assert.AreEqual(100, board.Score);
+
+            var columnShape = new BlockShape(new bool[,] {
+                { true }, { true }, { true }, { true }, { true }, { true }, { true }, { true }
+            });
+            board.TryPlacePiece(columnShape, 0, 0);
+            Assert.AreEqual(200, board.Score);
+        }
+
+        [Test]
+        public void DetectsGameOverWhenNoValidPlacements()
+        {
+            var board = new BoardGrid();
+            var spawner = new PieceSpawner();
+
+            var almostFull = new bool[BoardGrid.Size, BoardGrid.Size];
+            for (var y = 0; y < BoardGrid.Size; y++)
+            {
+                for (var x = 0; x < BoardGrid.Size; x++)
+                {
+                    almostFull[y, x] = x != y; // leave a diagonal of empty cells
+                }
+            }
+            var shape = new BlockShape(almostFull);
+            board.TryPlacePiece(shape, 0, 0);
+
+            Assert.IsFalse(board.HasAnyValidPlacement(spawner.Shapes));
+        }
+    }
+}
+

--- a/TetrisMania.Tests.csproj
+++ b/TetrisMania.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Assets/Tests/**/*.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="TetrisMania.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+  </ItemGroup>
+</Project>

--- a/TetrisMania.csproj
+++ b/TetrisMania.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Assets/Scripts/**/*.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- Implement BoardGrid to manage an 8x8 playfield, clear lines, track score, and raise line-clear events
- Add PieceSpawner for random T, L, square, and line pieces
- Create PlacementValidator to ensure shapes fit on the board
- Provide unit tests for line clearing, scoring, and game-over conditions

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fb971968832aaba897cc78bd766a