### PR TITLE
Add score manager and game flow with ad/IAP stubs

### DIFF
--- a/Assets/Scripts/AdManager.cs
+++ b/Assets/Scripts/AdManager.cs
@@ -1,0 +1,24 @@
+namespace TetrisMania
+{
+    /// <summary>
+    /// Placeholder ad manager for rewarded and interstitial ads.
+    /// </summary>
+    public class AdManager
+    {
+        /// <summary>
+        /// Simulates displaying a rewarded ad.
+        /// </summary>
+        /// <returns><c>true</c> to indicate the ad was "watched" successfully.</returns>
+        public bool ShowRewardedAd()
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// Simulates displaying an interstitial ad.
+        /// </summary>
+        public void ShowInterstitialAd()
+        {
+        }
+    }
+}

--- a/Assets/Scripts/BoardGrid.cs
+++ b/Assets/Scripts/BoardGrid.cs
@@ -43,11 +43,6 @@ namespace TetrisMania
         public event Action<int>? LinesCleared;
 
         /// <summary>
-        /// Gets the player's score.
-        /// </summary>
-        public int Score { get; private set; }
-
-        /// <summary>
         /// Attempts to place a shape at the specified board coordinates.
         /// </summary>
         /// <param name="shape">Shape to place.</param>
@@ -70,7 +65,6 @@ namespace TetrisMania
             var cleared = ClearLines();
             if (cleared > 0)
             {
-                Score += cleared * 100;
                 LinesCleared?.Invoke(cleared);
             }
 

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1,0 +1,108 @@
+using System;
+
+namespace TetrisMania
+{
+    /// <summary>
+    /// Coordinates core game flow including start, game over and restart.
+    /// </summary>
+    public class GameManager
+    {
+        private readonly AdManager _adManager;
+        private BoardGrid _board = new BoardGrid();
+        private PieceSpawner _spawner = new PieceSpawner();
+        private readonly ScoreManager _scoreManager = new ScoreManager();
+        private bool _gameOver;
+        private bool _reviveUsed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GameManager"/> class.
+        /// </summary>
+        /// <param name="adManager">Ad system used for revives.</param>
+        public GameManager(AdManager adManager)
+        {
+            _adManager = adManager ?? throw new ArgumentNullException(nameof(adManager));
+            _board.LinesCleared += _scoreManager.OnLinesCleared;
+        }
+
+        /// <summary>
+        /// Gets the current board grid.
+        /// </summary>
+        public BoardGrid Board => _board;
+
+        /// <summary>
+        /// Gets the piece spawner.
+        /// </summary>
+        public PieceSpawner Spawner => _spawner;
+
+        /// <summary>
+        /// Gets the score manager.
+        /// </summary>
+        public ScoreManager ScoreManager => _scoreManager;
+
+        /// <summary>
+        /// Gets a value indicating whether the game is over.
+        /// </summary>
+        public bool IsGameOver => _gameOver;
+
+        /// <summary>
+        /// Gets a value indicating whether the game over panel is visible.
+        /// </summary>
+        public bool GameOverPanelVisible { get; private set; }
+
+        /// <summary>
+        /// Starts a new game.
+        /// </summary>
+        public void StartGame()
+        {
+            _board = new BoardGrid();
+            _board.LinesCleared += _scoreManager.OnLinesCleared;
+            _spawner = new PieceSpawner();
+            _scoreManager.Reset();
+            _gameOver = false;
+            _reviveUsed = false;
+            GameOverPanelVisible = false;
+        }
+
+        /// <summary>
+        /// Checks for game over and displays the panel when no moves remain.
+        /// </summary>
+        public void CheckGameOver()
+        {
+            if (!_board.HasAnyValidPlacement(_spawner.Shapes))
+            {
+                _gameOver = true;
+                GameOverPanelVisible = true;
+            }
+        }
+
+        /// <summary>
+        /// Restarts the game from scratch.
+        /// </summary>
+        public void Restart()
+        {
+            StartGame();
+        }
+
+        /// <summary>
+        /// Attempts to revive the player via a rewarded ad.
+        /// </summary>
+        /// <returns><c>true</c> if the game resumed; otherwise, <c>false</c>.</returns>
+        public bool ReviveWithAd()
+        {
+            if (!_gameOver || _reviveUsed)
+            {
+                return false;
+            }
+
+            if (_adManager.ShowRewardedAd())
+            {
+                _gameOver = false;
+                GameOverPanelVisible = false;
+                _reviveUsed = true;
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Assets/Scripts/IAPManager.cs
+++ b/Assets/Scripts/IAPManager.cs
@@ -1,0 +1,22 @@
+namespace TetrisMania
+{
+    /// <summary>
+    /// Placeholder in-app purchase manager.
+    /// </summary>
+    public class IAPManager
+    {
+        /// <summary>
+        /// Simulates purchasing the no-ads pack.
+        /// </summary>
+        public void PurchaseNoAds()
+        {
+        }
+
+        /// <summary>
+        /// Simulates purchasing the starter pack.
+        /// </summary>
+        public void PurchaseStarterPack()
+        {
+        }
+    }
+}

--- a/Assets/Scripts/ScoreManager.cs
+++ b/Assets/Scripts/ScoreManager.cs
@@ -1,0 +1,41 @@
+namespace TetrisMania
+{
+    /// <summary>
+    /// Handles player scoring based on cleared lines.
+    /// </summary>
+    public class ScoreManager
+    {
+        private int _score;
+
+        /// <summary>
+        /// Gets the current score.
+        /// </summary>
+        public int Score => _score;
+
+        /// <summary>
+        /// Resets the score to zero.
+        /// </summary>
+        public void Reset()
+        {
+            _score = 0;
+        }
+
+        /// <summary>
+        /// Adds points for the specified number of cleared lines.
+        /// </summary>
+        /// <param name="lines">Number of lines cleared in a single move.</param>
+        public void OnLinesCleared(int lines)
+        {
+            if (lines <= 0)
+            {
+                return;
+            }
+
+            _score += lines * 100;
+            if (lines > 1)
+            {
+                _score += 50 * (lines - 1);
+            }
+        }
+    }
+}

--- a/Assets/Tests/BoardGridTests.cs
+++ b/Assets/Tests/BoardGridTests.cs
@@ -31,24 +31,6 @@ namespace TetrisMania.Tests
         }
 
         [Test]
-        public void AwardsScoreForClears()
-        {
-            var board = new BoardGrid();
-
-            var rowShape = new BlockShape(new bool[,] {
-                { true, true, true, true, true, true, true, true }
-            });
-            board.TryPlacePiece(rowShape, 0, 0);
-            Assert.AreEqual(100, board.Score);
-
-            var columnShape = new BlockShape(new bool[,] {
-                { true }, { true }, { true }, { true }, { true }, { true }, { true }, { true }
-            });
-            board.TryPlacePiece(columnShape, 0, 0);
-            Assert.AreEqual(200, board.Score);
-        }
-
-        [Test]
         public void DetectsGameOverWhenNoValidPlacements()
         {
             var board = new BoardGrid();

--- a/Assets/Tests/ScoreManagerTests.cs
+++ b/Assets/Tests/ScoreManagerTests.cs
@@ -1,0 +1,41 @@
+using NUnit.Framework;
+using TetrisMania;
+
+namespace TetrisMania.Tests
+{
+    public class ScoreManagerTests
+    {
+        [Test]
+        public void AwardsPointsForSingleLine()
+        {
+            var manager = new ScoreManager();
+            manager.OnLinesCleared(1);
+            Assert.AreEqual(100, manager.Score);
+        }
+
+        [Test]
+        public void AwardsBonusForMultipleLines()
+        {
+            var manager = new ScoreManager();
+            manager.OnLinesCleared(2);
+            Assert.AreEqual(250, manager.Score);
+
+            manager.Reset();
+            manager.OnLinesCleared(3);
+            Assert.AreEqual(400, manager.Score);
+
+            manager.Reset();
+            manager.OnLinesCleared(4);
+            Assert.AreEqual(550, manager.Score);
+        }
+
+        [Test]
+        public void IgnoresNonPositiveInput()
+        {
+            var manager = new ScoreManager();
+            manager.OnLinesCleared(0);
+            manager.OnLinesCleared(-1);
+            Assert.AreEqual(0, manager.Score);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ScoreManager` for line-clear scoring with multi-line bonuses
- Introduce `GameManager` to coordinate board, spawner, score, and ad-based revive
- Provide stub `AdManager` and `IAPManager`
- Cover scoring rules with new unit tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fce4fffc832aae825cfbf5c2d734