### PR TITLE
Add game flow integration tests with ad and IAP interfaces

### DIFF
--- a/Assets/Scripts/AdManager.cs
+++ b/Assets/Scripts/AdManager.cs
@@ -1,10 +1,24 @@
+using System;
+
 namespace TetrisMania
 {
     /// <summary>
     /// Placeholder ad manager for rewarded and interstitial ads.
     /// </summary>
-    public class AdManager
+    public class AdManager : IAdManager
     {
+        private readonly IIAPManager _iapManager;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AdManager"/> class.
+        /// </summary>
+        /// <param name="iapManager">IAP system used to check for no-ads purchases.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="iapManager"/> is null.</exception>
+        public AdManager(IIAPManager iapManager)
+        {
+            _iapManager = iapManager ?? throw new ArgumentNullException(nameof(iapManager));
+        }
+
         /// <summary>
         /// Simulates displaying a rewarded ad.
         /// </summary>
@@ -17,8 +31,15 @@ namespace TetrisMania
         /// <summary>
         /// Simulates displaying an interstitial ad.
         /// </summary>
-        public void ShowInterstitialAd()
+        /// <returns><c>true</c> if the ad is shown; otherwise, <c>false</c>.</returns>
+        public bool ShowInterstitialAd()
         {
+            if (_iapManager.HasNoAds)
+            {
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -7,7 +7,7 @@ namespace TetrisMania
     /// </summary>
     public class GameManager
     {
-        private readonly AdManager _adManager;
+        private readonly IAdManager _adManager;
         private BoardGrid _board = new BoardGrid();
         private PieceSpawner _spawner = new PieceSpawner();
         private readonly ScoreManager _scoreManager = new ScoreManager();
@@ -18,7 +18,7 @@ namespace TetrisMania
         /// Initializes a new instance of the <see cref="GameManager"/> class.
         /// </summary>
         /// <param name="adManager">Ad system used for revives.</param>
-        public GameManager(AdManager adManager)
+        public GameManager(IAdManager adManager)
         {
             _adManager = adManager ?? throw new ArgumentNullException(nameof(adManager));
             _board.LinesCleared += _scoreManager.OnLinesCleared;

--- a/Assets/Scripts/IAPManager.cs
+++ b/Assets/Scripts/IAPManager.cs
@@ -1,15 +1,23 @@
+using System;
+
 namespace TetrisMania
 {
     /// <summary>
     /// Placeholder in-app purchase manager.
     /// </summary>
-    public class IAPManager
+    public class IAPManager : IIAPManager
     {
+        /// <summary>
+        /// Gets a value indicating whether the player owns the no-ads pack.
+        /// </summary>
+        public bool HasNoAds { get; private set; }
+
         /// <summary>
         /// Simulates purchasing the no-ads pack.
         /// </summary>
         public void PurchaseNoAds()
         {
+            HasNoAds = true;
         }
 
         /// <summary>

--- a/Assets/Scripts/IAdManager.cs
+++ b/Assets/Scripts/IAdManager.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace TetrisMania
+{
+    /// <summary>
+    /// Interface for ad management.
+    /// </summary>
+    public interface IAdManager
+    {
+        /// <summary>
+        /// Displays a rewarded ad.
+        /// </summary>
+        /// <returns>True if the ad was shown successfully.</returns>
+        bool ShowRewardedAd();
+
+        /// <summary>
+        /// Displays an interstitial ad if allowed.
+        /// </summary>
+        /// <returns>True when an interstitial ad is shown.</returns>
+        bool ShowInterstitialAd();
+    }
+}

--- a/Assets/Scripts/IIAPManager.cs
+++ b/Assets/Scripts/IIAPManager.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace TetrisMania
+{
+    /// <summary>
+    /// Interface for in-app purchase functionality.
+    /// </summary>
+    public interface IIAPManager
+    {
+        /// <summary>
+        /// Gets a value indicating whether the no-ads purchase was made.
+        /// </summary>
+        bool HasNoAds { get; }
+    }
+}

--- a/Assets/Tests/GameFlowTests.cs
+++ b/Assets/Tests/GameFlowTests.cs
@@ -1,0 +1,103 @@
+using NUnit.Framework;
+using TetrisMania;
+
+namespace TetrisMania.Tests
+{
+    public class GameFlowTests
+    {
+        private class FakeAdManager : IAdManager
+        {
+            public bool RewardedShown { get; private set; }
+            public bool InterstitialShown { get; private set; }
+
+            public bool ShowRewardedAd()
+            {
+                RewardedShown = true;
+                return true;
+            }
+
+            public bool ShowInterstitialAd()
+            {
+                InterstitialShown = true;
+                return true;
+            }
+        }
+
+        private class FakeIAPManager : IIAPManager
+        {
+            public bool HasNoAds { get; set; }
+        }
+
+        [Test]
+        public void GameOver_Fires_WhenNoMovesRemain()
+        {
+            var adManager = new FakeAdManager();
+            var gameManager = new GameManager(adManager);
+
+            var almostFull = new bool[BoardGrid.Size, BoardGrid.Size];
+            for (var y = 0; y < BoardGrid.Size; y++)
+            {
+                for (var x = 0; x < BoardGrid.Size; x++)
+                {
+                    almostFull[y, x] = x != y;
+                }
+            }
+
+            var shape = new BlockShape(almostFull);
+            Assert.IsTrue(gameManager.Board.TryPlacePiece(shape, 0, 0));
+
+            gameManager.CheckGameOver();
+
+            Assert.IsTrue(gameManager.IsGameOver);
+        }
+
+        [Test]
+        public void Revive_WithRewarded_ResumesPlay()
+        {
+            var adManager = new FakeAdManager();
+            var gameManager = new GameManager(adManager);
+
+            var almostFull = new bool[BoardGrid.Size, BoardGrid.Size];
+            for (var y = 0; y < BoardGrid.Size; y++)
+            {
+                for (var x = 0; x < BoardGrid.Size; x++)
+                {
+                    almostFull[y, x] = x != y;
+                }
+            }
+
+            var shape = new BlockShape(almostFull);
+            Assert.IsTrue(gameManager.Board.TryPlacePiece(shape, 0, 0));
+            gameManager.CheckGameOver();
+            Assert.IsTrue(gameManager.IsGameOver);
+
+            Assert.IsTrue(gameManager.ReviveWithAd());
+            Assert.IsFalse(gameManager.IsGameOver);
+            Assert.IsTrue(adManager.RewardedShown);
+        }
+
+        [Test]
+        public void NoAdsPurchase_DisablesInterstitials()
+        {
+            var iapManager = new FakeIAPManager { HasNoAds = true };
+            var adManager = new AdManager(iapManager);
+            var gameManager = new GameManager(adManager);
+
+            var almostFull = new bool[BoardGrid.Size, BoardGrid.Size];
+            for (var y = 0; y < BoardGrid.Size; y++)
+            {
+                for (var x = 0; x < BoardGrid.Size; x++)
+                {
+                    almostFull[y, x] = x != y;
+                }
+            }
+
+            var shape = new BlockShape(almostFull);
+            Assert.IsTrue(gameManager.Board.TryPlacePiece(shape, 0, 0));
+            gameManager.CheckGameOver();
+            Assert.IsTrue(gameManager.IsGameOver);
+
+            Assert.IsFalse(adManager.ShowInterstitialAd());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce `IAdManager` and `IIAPManager` interfaces for dependency injection
- Update ad and game managers to respect no-ads purchases
- Add comprehensive `GameFlowTests` covering game over, revive, and interstitial suppression

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6a61d7f8832a8c699023bdd1403c