### PR TITLE
Convert core systems to MonoBehaviours

### DIFF
--- a/Assets/Scripts/BoardGrid.cs
+++ b/Assets/Scripts/BoardGrid.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace TetrisMania
 {
@@ -27,15 +28,28 @@ namespace TetrisMania
     /// <summary>
     /// Manages the main 8x8 board grid, handling block placement and line clears.
     /// </summary>
-    public class BoardGrid
+    public class BoardGrid : MonoBehaviour
     {
         /// <summary>
         /// Size of the board on each axis.
         /// </summary>
         public const int Size = 8;
 
-        private readonly bool[,] _grid = new bool[Size, Size];
+        private bool[,] _grid = null!;
         private readonly PlacementValidator _validator = new PlacementValidator();
+
+        private void Awake()
+        {
+            _grid = new bool[Size, Size];
+        }
+
+        /// <summary>
+        /// Resets the grid to an empty state.
+        /// </summary>
+        public void ResetGrid()
+        {
+            _grid = new bool[Size, Size];
+        }
 
         /// <summary>
         /// Raised whenever one or more lines are cleared.

--- a/Assets/Scripts/PieceSpawner.cs
+++ b/Assets/Scripts/PieceSpawner.cs
@@ -1,22 +1,20 @@
 using System;
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace TetrisMania
 {
     /// <summary>
     /// Provides random block shapes for gameplay.
     /// </summary>
-    public class PieceSpawner
+    public class PieceSpawner : MonoBehaviour
     {
         private readonly Random _random = new Random();
-        private readonly List<BlockShape> _shapes;
+        private readonly List<BlockShape> _shapes = new List<BlockShape>();
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PieceSpawner"/> class.
-        /// </summary>
-        public PieceSpawner()
+        private void Awake()
         {
-            _shapes = new List<BlockShape>
+            _shapes.AddRange(new List<BlockShape>
             {
                 // T shape
                 new BlockShape(new bool[,]
@@ -42,7 +40,7 @@ namespace TetrisMania
                 {
                     { true, true, true, true }
                 })
-            };
+            });
         }
 
         /// <summary>

--- a/Assets/Scripts/ScoreManager.cs
+++ b/Assets/Scripts/ScoreManager.cs
@@ -1,9 +1,11 @@
+using UnityEngine;
+
 namespace TetrisMania
 {
     /// <summary>
     /// Handles player scoring based on cleared lines.
     /// </summary>
-    public class ScoreManager
+    public class ScoreManager : MonoBehaviour
     {
         private int _score;
 

--- a/Assets/Scripts/UnityStubs.cs
+++ b/Assets/Scripts/UnityStubs.cs
@@ -1,0 +1,23 @@
+#if !UNITY_5_3_OR_NEWER
+using System;
+using System.Reflection;
+
+namespace UnityEngine
+{
+    public class MonoBehaviour { }
+
+    [AttributeUsage(AttributeTargets.Field)]
+    public sealed class SerializeField : Attribute { }
+
+    public class GameObject
+    {
+        public T AddComponent<T>() where T : new()
+        {
+            var instance = new T();
+            var method = typeof(T).GetMethod("Awake", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+            method?.Invoke(instance, null);
+            return instance;
+        }
+    }
+}
+#endif

--- a/Assets/Tests/BoardGridTests.cs
+++ b/Assets/Tests/BoardGridTests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using System.Collections.Generic;
 using TetrisMania;
+using UnityEngine;
 
 namespace TetrisMania.Tests
 {
@@ -9,7 +10,7 @@ namespace TetrisMania.Tests
         [Test]
         public void ClearsFullRowAndColumn()
         {
-            var board = new BoardGrid();
+            var board = new GameObject().AddComponent<BoardGrid>();
             var clearedTotal = 0;
             board.LinesCleared += c => clearedTotal += c;
 
@@ -33,8 +34,8 @@ namespace TetrisMania.Tests
         [Test]
         public void DetectsGameOverWhenNoValidPlacements()
         {
-            var board = new BoardGrid();
-            var spawner = new PieceSpawner();
+            var board = new GameObject().AddComponent<BoardGrid>();
+            var spawner = new GameObject().AddComponent<PieceSpawner>();
 
             var almostFull = new bool[BoardGrid.Size, BoardGrid.Size];
             for (var y = 0; y < BoardGrid.Size; y++)

--- a/Assets/Tests/GameFlowTests.cs
+++ b/Assets/Tests/GameFlowTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using TetrisMania;
+using UnityEngine;
 
 namespace TetrisMania.Tests
 {
@@ -32,7 +33,11 @@ namespace TetrisMania.Tests
         public void GameOver_Fires_WhenNoMovesRemain()
         {
             var adManager = new FakeAdManager();
-            var gameManager = new GameManager(adManager);
+            var board = new GameObject().AddComponent<BoardGrid>();
+            var spawner = new GameObject().AddComponent<PieceSpawner>();
+            var score = new GameObject().AddComponent<ScoreManager>();
+            var gameManager = new GameObject().AddComponent<GameManager>();
+            gameManager.Initialize(board, spawner, score, adManager);
 
             var almostFull = new bool[BoardGrid.Size, BoardGrid.Size];
             for (var y = 0; y < BoardGrid.Size; y++)
@@ -55,7 +60,11 @@ namespace TetrisMania.Tests
         public void Revive_WithRewarded_ResumesPlay()
         {
             var adManager = new FakeAdManager();
-            var gameManager = new GameManager(adManager);
+            var board = new GameObject().AddComponent<BoardGrid>();
+            var spawner = new GameObject().AddComponent<PieceSpawner>();
+            var score = new GameObject().AddComponent<ScoreManager>();
+            var gameManager = new GameObject().AddComponent<GameManager>();
+            gameManager.Initialize(board, spawner, score, adManager);
 
             var almostFull = new bool[BoardGrid.Size, BoardGrid.Size];
             for (var y = 0; y < BoardGrid.Size; y++)
@@ -81,7 +90,11 @@ namespace TetrisMania.Tests
         {
             var iapManager = new FakeIAPManager { HasNoAds = true };
             var adManager = new AdManager(iapManager);
-            var gameManager = new GameManager(adManager);
+            var board = new GameObject().AddComponent<BoardGrid>();
+            var spawner = new GameObject().AddComponent<PieceSpawner>();
+            var score = new GameObject().AddComponent<ScoreManager>();
+            var gameManager = new GameObject().AddComponent<GameManager>();
+            gameManager.Initialize(board, spawner, score, adManager);
 
             var almostFull = new bool[BoardGrid.Size, BoardGrid.Size];
             for (var y = 0; y < BoardGrid.Size; y++)

--- a/Assets/Tests/ScoreManagerTests.cs
+++ b/Assets/Tests/ScoreManagerTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using TetrisMania;
+using UnityEngine;
 
 namespace TetrisMania.Tests
 {
@@ -8,7 +9,7 @@ namespace TetrisMania.Tests
         [Test]
         public void AwardsPointsForSingleLine()
         {
-            var manager = new ScoreManager();
+            var manager = new GameObject().AddComponent<ScoreManager>();
             manager.OnLinesCleared(1);
             Assert.AreEqual(100, manager.Score);
         }
@@ -16,7 +17,7 @@ namespace TetrisMania.Tests
         [Test]
         public void AwardsBonusForMultipleLines()
         {
-            var manager = new ScoreManager();
+            var manager = new GameObject().AddComponent<ScoreManager>();
             manager.OnLinesCleared(2);
             Assert.AreEqual(250, manager.Score);
 
@@ -32,7 +33,7 @@ namespace TetrisMania.Tests
         [Test]
         public void IgnoresNonPositiveInput()
         {
-            var manager = new ScoreManager();
+            var manager = new GameObject().AddComponent<ScoreManager>();
             manager.OnLinesCleared(0);
             manager.OnLinesCleared(-1);
             Assert.AreEqual(0, manager.Score);


### PR DESCRIPTION
## Summary
- Convert BoardGrid, GameManager, PieceSpawner and ScoreManager into `MonoBehaviour` components usable in the Unity Editor
- Initialize BoardGrid grid in `Awake` and add reset support
- Add helper stubs for basic UnityEngine types to allow testing outside Unity

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb32fb75fc832abfd0a5c2a22a0b02